### PR TITLE
Turn "remove selected command" QPushButton into a QToolButton

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -2100,7 +2100,7 @@ def pieMenuStart():
 
     buttonDown.clicked.connect(onButtonDown)
 
-    buttonRemoveCommand = QtGui.QPushButton()
+    buttonRemoveCommand = QtGui.QToolButton()
     buttonRemoveCommand.setIcon(QtGui.QIcon(iconRemoveCommand))
     buttonRemoveCommand.setToolTip("Remove selected command")
     buttonRemoveCommand.setMinimumHeight(30)


### PR DESCRIPTION
The whole GUI is made with QToolButtons so it's better not to mix them. It makes styling easier and more homogeneous.