### PR TITLE
Add object name to Qlabel when using Command names in pie

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -848,7 +848,9 @@ def pieMenuStart():
                         layout.setContentsMargins((icon/4), 0, 0, 0)
                         iconButton = QtGui.QIcon(commands[commands.index(i)].icon())
                         iconLabel = QtGui.QLabel()
+                        iconLabel.setObjectName("iconLabel")
                         iconLabel.setPixmap(iconButton.pixmap(QtCore.QSize(icon, icon)))
+                        iconLabel.setStyleSheet(styleCurrentTheme)
                         layout.addWidget(iconLabel)
 
                     if shape == "TableTop":

--- a/Resources/Stylesheets/Dark behave.qss
+++ b/Resources/Stylesheets/Dark behave.qss
@@ -106,3 +106,15 @@ QMenu#styleQuickMenuItem::item {
 QToolButton#styleButtonMenu::menu-indicator {
     image: none;
 }
+
+QFrame#separatorPieMenu,
+QFrame#separatorSettings {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px solid transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Important fix to override QLabel styling from FreeCAD stylesheets, do not remove */
+QLabel#iconLabel {
+    background-color: transparent;
+}

--- a/Resources/Stylesheets/Dark.qss
+++ b/Resources/Stylesheets/Dark.qss
@@ -102,3 +102,15 @@ QMenu#styleQuickMenuItem::item {
 QToolButton#styleButtonMenu::menu-indicator {
     image: none;
 }
+
+QFrame#separatorPieMenu,
+QFrame#separatorSettings {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px solid transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Important fix to override QLabel styling from FreeCAD stylesheets, do not remove */
+QLabel#iconLabel {
+    background-color: transparent;
+}

--- a/Resources/Stylesheets/Legacy.qss
+++ b/Resources/Stylesheets/Legacy.qss
@@ -105,3 +105,15 @@ QMenu#styleQuickMenuItem::item {
 QToolButton#styleButtonMenu::menu-indicator {
     image: none;
 }
+
+QFrame#separatorPieMenu,
+QFrame#separatorSettings {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px solid transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Important fix to override QLabel styling from FreeCAD stylesheets, do not remove */
+QLabel#iconLabel {
+    background-color: transparent;
+}

--- a/Resources/Stylesheets/Light.qss
+++ b/Resources/Stylesheets/Light.qss
@@ -102,3 +102,15 @@ QMenu#styleQuickMenuItem::item {
 QToolButton#styleButtonMenu::menu-indicator {
     image: none;
 }
+
+QFrame#separatorPieMenu,
+QFrame#separatorSettings {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px solid transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Important fix to override QLabel styling from FreeCAD stylesheets, do not remove */
+QLabel#iconLabel {
+    background-color: transparent;
+}

--- a/Resources/Stylesheets/Transparent.qss
+++ b/Resources/Stylesheets/Transparent.qss
@@ -102,3 +102,15 @@ QMenu#styleQuickMenuItem::item {
 QToolButton#styleButtonMenu::menu-indicator {
     image: none;
 }
+
+QFrame#separatorPieMenu,
+QFrame#separatorSettings {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px solid transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Important fix to override QLabel styling from FreeCAD stylesheets, do not remove */
+QLabel#iconLabel {
+    background-color: transparent;
+}


### PR DESCRIPTION
As there might be a conflict with FreeCAD stylesheets that apply a style to default QLabels.
Naming our QLabel we can override any style applied to it that could interfere with what we need inside the pie.

For example, I was getting this problem in one of the stylesheets I'm working on now:
<img width="703" alt="pie_error" src="https://github.com/Grubuntu/PieMenu-Improved/assets/5942369/10084119-76cd-467c-bb41-6dbb128698a9">
